### PR TITLE
Fix ckcov

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,16 @@ Any CSPICE function that expects a `SpiceCell` as an input can also be passed an
 a tuple, or anything that can reasonably be converted into an appropriately typed
 `SpiceCell`:
 
+Any CSPICE function that returns a `SpiceCell` as a result takes an optional final
+argument.  
+* If this argument is omitted, a `SpiceCell` with a function-specific default capacity
+  will be created, and the output will be placed into it. 
+* If this argument is a `SpiceCell`, it will be used as the output argument.
+* If this argument is an integer, a `SpiceCell` with that capacity will be created and
+  used as the output.
+
+In all cases, the `SpiceCell` output will also be a return value.
+
 ```shell
 >>> import cspyce
 >>> cspyce.wninsd(2.0, 4.9, (1.0, 3.0, 5.0, 7.0, 9.0, 11.0))

--- a/cspyce/cspyce1.py
+++ b/cspyce/cspyce1.py
@@ -183,8 +183,8 @@ def cidfrm_error(code):
 
     return [frcode, name]
 
-def ckcov_error(ck, idcode, needav, level, tol, timsys):
-    coverage = cspyce0.ckcov(ck, idcode, needav, level, tol, timsys)
+def ckcov_error(ck, idcode, needav, level, tol, timsys, coverage):
+    coverage = cspyce0.ckcov(ck, idcode, needav, level, tol, timsys, coverage)
     if coverage.card == 0:
         with chkin_and_chkout('ckcov_error'):
             setmsg(f'body code {idcode} not found in C kernel file {ck}')
@@ -362,8 +362,8 @@ def namfrm1_error(frname):  # change of name; namfrm_error is defined below
 
     return frcode
 
-def pckcov_error(pck, code):
-    coverage = cspyce0.pckcov(pck, code)
+def pckcov_error(pck, code, coverage):
+    coverage = cspyce0.pckcov(pck, code, coverage)
     if coverage.card == 0:
         with chkin_and_chkout('pckcov_error'):
             setmsg(f'frame code {code} not found in binary PC kernel file {pck}')
@@ -371,8 +371,8 @@ def pckcov_error(pck, code):
 
     return coverage
 
-def spkcov_error(spk, code):
-    coverage = cspyce0.spkcov(spk, code)
+def spkcov_error(spk, code, coverage):
+    coverage = cspyce0.spkcov(spk, code, coverage)
     if coverage.card == 0:
         with chkin_and_chkout('spkcov_error'):
             setmsg(f'body code {code} not found in SP kernel file {spk}')

--- a/cspyce/spice_cell.py
+++ b/cspyce/spice_cell.py
@@ -38,6 +38,8 @@ class SpiceCell:
     def as_spice_cell(my_type, record):
         if isinstance(record, SpiceCell) and record._header._dtype == my_type:
             return record
+        if isinstance(record, int):
+            return SpiceCell.create_spice_cell(my_type, record)
         return SpiceCell(data=record, typeno=my_type)
 
     def __init__(self, data=None, typeno=None, size: int = 0, length: int = 0):

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -816,13 +816,6 @@ class Test_SpiceCell_Typemap():
         # This function sums the items of the integer SpiceCell.
         assert ts.SpiceCell_in(cell) == 10
 
-    def test_spice_cell_out(self):
-        # This function returns a double SpiceCell with a single element
-        cell = ts.SpiceCell_out(1.0)
-        assert isinstance(cell, SpiceCell)
-        assert list(cell) == [1.0]
-        assert isinstance(cell[0], float)
-
     def test_spice_cell_in_out(self):
         cell = SpiceCell((1, 2, 3, 4))
         # This appends the value to the integer SpiceCell

--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -6026,12 +6026,14 @@ extern void pckcov_c(
 %rename (pckfrm) pckfrm_c;
 %apply (void RETURN_VOID) {void pckfrm_c};
 %apply (ConstSpiceChar *CONST_FILENAME) {ConstSpiceChar *pck};
-%apply (SpiceCellInt *OUTPUT) {SpiceCell *ids};
+%apply (SpiceCellInt *INOUT) {SpiceCell *ids};
 
 extern void pckfrm_c(
         ConstSpiceChar *pck,
         SpiceCell      *ids
 );
+//CSPYCE_DEFAULT:ids:2000
+
 
 /***********************************************************************
 * -Procedure pcpool_c ( Put character strings into the kernel pool )

--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -256,7 +256,7 @@ extern SpiceDouble b1950_c (void);
 
 %rename (bltfrm) bltfrm_c;
 %apply (void RETURN_VOID) {void bltfrm_c};
-%apply (SpiceCellInt *OUTPUT) {SpiceCell *ids};
+%apply (SpiceCellInt *INOUT) {SpiceCell *ids};
 
 extern void bltfrm_c(
         SpiceInt frmcls,
@@ -264,6 +264,7 @@ extern void bltfrm_c(
 );
 
 //CSPYCE_TYPE:ids:frame_code
+//CSPYCE_DEFAULT:ids:1000
 
 /***********************************************************************
 * -Procedure bodc2n_c ( Body ID code to name translation )
@@ -807,7 +808,7 @@ extern void chkout_c(
 %apply (ConstSpiceChar *CONST_FILENAME) {ConstSpiceChar *ck};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *level};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *timsys};
-%apply (SpiceCellDouble *OUTPUT) {SpiceCell *cover};
+%apply (SpiceCellDouble *INOUT) {SpiceCell *cover};
 
 extern void ckcov_c(
         ConstSpiceChar *ck,
@@ -820,6 +821,7 @@ extern void ckcov_c(
 );
 
 //CSPYCE_TYPE:idcode:body_code
+//CSPYCE_DEFAULT:cover:20000
 
 /***********************************************************************
 * -Procedure ckgp_c ( C-kernel, get pointing )
@@ -947,7 +949,7 @@ extern void ckobj_c(
         SpiceCell      *bodids
 );
 
-//CSPYCE_DEFAULT:bodids:()
+//CSPYCE_DEFAULT:bodids:1000
 
 /***********************************************************************
 * -Procedure clight_c ( C, Speed of light in a vacuum )
@@ -4424,7 +4426,7 @@ extern SpiceDouble jyear_c(void);
 
 %rename (kplfrm) kplfrm_c;
 %apply (void RETURN_VOID) {void kplfrm_c};
-%apply (SpiceCellInt *OUTPUT) {SpiceCell *ids};
+%apply (SpiceCellInt *INOUT) {SpiceCell *ids};
 
 extern void kplfrm_c(
         SpiceInt frmcls,
@@ -4432,6 +4434,7 @@ extern void kplfrm_c(
 );
 
 //CSPYCE_TYPE:ids:frame_code
+//CSPYCE_DEFAULT:ids:1000
 
 /***********************************************************************
 * -Procedure latcyl_c ( Latitudinal to cylindrical coordinates )
@@ -5987,13 +5990,15 @@ VECTORIZE_dX_2d__dN(oscltx, oscltx_c, SPICE_OSCLTX_NELTS)
 %rename (pckcov) pckcov_c;
 %apply (void RETURN_VOID) {void pckcov_c};
 %apply (ConstSpiceChar *CONST_FILENAME) {ConstSpiceChar *pck};
-%apply (SpiceCellDouble *OUTPUT) {SpiceCell* cover};
+%apply (SpiceCellDouble *INOUT) {SpiceCell* cover};
 
 extern void pckcov_c(
         ConstSpiceChar *pck,
         SpiceInt       idcode,
         SpiceCell      *cover
 );
+//CSPYCE_DEFAULT:cover:2000
+
 
 //CSPYCE_TYPE:idcode:frame_code
 
@@ -8614,14 +8619,14 @@ VECTORIZE_i_d_2s_dX_dX__dN_d_d(spkaps, spkaps_c, 6)
 %rename (spkcov) spkcov_c;
 %apply (void RETURN_VOID) {void spkcov_c};
 %apply (ConstSpiceChar *CONST_FILENAME) {ConstSpiceChar *spk};
-%apply (SpiceCellDouble *OUTPUT) {SpiceCell *cover};
+%apply (SpiceCellDouble *INOUT) {SpiceCell *cover};
 
 extern void spkcov_c(
         ConstSpiceChar *spk,
         SpiceInt       idcode,
         SpiceCell      *cover
 );
-
+//CSPYCE_DEFAULT:cover:2000
 //CSPYCE_TYPE:idcode:body_code
 
 /***********************************************************************
@@ -8930,7 +8935,7 @@ VECTORIZE_i_d_2s_dX__dN_d_d(spkltc, spkltc_c, 6)
 %rename (spkobj)  spkobj_c;
 %apply (void RETURN_VOID) {void spkobj_c};
 %apply (ConstSpiceChar *CONST_FILENAME) {ConstSpiceChar *spk};
-%apply (SpiceCellInt *OUTPUT) {SpiceCell *ids};
+%apply (SpiceCellInt *INOUT) {SpiceCell *ids};
 
 extern void spkobj_c(
         ConstSpiceChar *spk,
@@ -8938,6 +8943,7 @@ extern void spkobj_c(
 );
 
 //CSPYCE_TYPE:ids:body_code
+//CSPYCE_DEFAULT:ids:1000
 
 /***********************************************************************
 * -Procedure spkpos_c ( S/P Kernel, position )

--- a/swig/cspyce0_part2.i
+++ b/swig/cspyce0_part2.i
@@ -6338,7 +6338,7 @@ extern void gfdist_c(
 %apply (ConstSpiceDouble IN_ARRAY1[ANY]) {ConstSpiceDouble spoint[3]};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *relate};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 extern void gfilum_c(
         ConstSpiceChar   *method,
@@ -6357,6 +6357,7 @@ extern void gfilum_c(
         SpiceCell        *cnfine,
         SpiceCell        *result
 );
+//CSPYCE_DEFAULT:result:2000
 
 /***********************************************************************
 * -Procedure gfocce_c ( GF, occultation event )
@@ -11500,7 +11501,7 @@ VECTORIZE_di_di__di(vprojg, my_vprojg_nomalloc)
 %rename (wncomd) wncomd_c;
 %apply (void RETURN_VOID) {void wncomd_c};
 %apply (SpiceCellDouble* INPUT) {SpiceCell *window};
-%apply (SpiceCellDouble* OUTPUT) {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT) {SpiceCell *result};
 
 extern void wncomd_c(
         SpiceDouble left,
@@ -11508,6 +11509,7 @@ extern void wncomd_c(
         SpiceCell   *window,
         SpiceCell   *result
 );
+//CSPYCE_DEFAULT:result:2000
 
 /***********************************************************************
 * -Procedure wncond_c ( Contract the intervals of a DP window )
@@ -11564,16 +11566,16 @@ extern void wncond_c(
 
 %rename (wndifd) wndifd_c;
 %apply (void RETURN_VOID) {void wndifd_c};
-
 %apply (SpiceCellDouble* INPUT) {SpiceCell *a};
 %apply (SpiceCellDouble* INPUT) {SpiceCell *b};
-%apply (SpiceCellDouble* OUTPUT) {SpiceCell *c};
+%apply (SpiceCellDouble* INOUT) {SpiceCell *c};
 
 extern void wndifd_c(
         SpiceCell *a,
         SpiceCell *b,
         SpiceCell *c
 );
+//CSPYCE_DEFAULT:c:2000
 
 /***********************************************************************
 * -Procedure wnelmd_c ( Element of a DP window )
@@ -11814,13 +11816,15 @@ extern void wninsd_c(
 %apply (void RETURN_VOID) {void wnintd_c};
 %apply (SpiceCellDouble* INPUT) {SpiceCell *a};
 %apply (SpiceCellDouble* INPUT) {SpiceCell *b};
-%apply (SpiceCellDouble* OUTPUT) {SpiceCell *c};
+%apply (SpiceCellDouble* INOUT) {SpiceCell *c};
 
 extern void wnintd_c(
         SpiceCell *a,
         SpiceCell *b,
         SpiceCell *c
 );
+//CSPYCE_DEFAULT:c:2000
+
 
 /***********************************************************************
 * -Procedure wnreld_c ( Compare two DP windows )
@@ -11932,12 +11936,14 @@ extern void wnsumd_c(
 %apply (void RETURN_VOID) {void wnunid_c};
 %apply (SpiceCellDouble* INPUT) {SpiceCell *a};
 %apply (SpiceCellDouble* INPUT) {SpiceCell *b};
-%apply (SpiceCellDouble* OUTPUT) {SpiceCell *c};
+%apply (SpiceCellDouble* INOUT) {SpiceCell *c};
 
 extern void wnunid_c(
         SpiceCell *a,
         SpiceCell *b,
         SpiceCell *c
 );
+//CSPYCE_DEFAULT:c:2000
+
 
 /**********************************************************************/

--- a/swig/cspyce0_part2.i
+++ b/swig/cspyce0_part2.i
@@ -3495,7 +3495,7 @@ extern void dskobj_c(
         SpiceCell *bodids
 );
 
-//CSPYCE_DEFAULT:bodids:()
+//CSPYCE_DEFAULT:bodids:10000
 
 /***********************************************************************
 * -Procedure dskopn_c ( DSK, open new file )
@@ -3661,7 +3661,7 @@ extern void dsksrf_c(
         SpiceCell      *srfids
 );
 
-//CSPYCE_DEFAULT:srfids:()
+//CSPYCE_DEFAULT:srfids:10000
 
 
 /***********************************************************************
@@ -6019,7 +6019,7 @@ extern SpiceInt esrchc_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *relate};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 extern void gfdist_c(
         ConstSpiceChar *target,
@@ -6033,6 +6033,8 @@ extern void gfdist_c(
         SpiceCell      *cnfine,
         SpiceCell      *result
 );
+//CSPYCE_DEFAULT:result:2000
+
 
 /***********************************************************************
 * -Procedure gfevnt_c (GF, geometric event finder )
@@ -6121,7 +6123,7 @@ extern void gfdist_c(
 %apply (ConstSpiceBoolean *IN_ARRAY1) {ConstSpiceBoolean *qlpars};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar    *op};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 %inline %{
     void my_gfevnt_c(
@@ -6173,6 +6175,7 @@ extern void gfdist_c(
         PyMem_Free(temp);
     }
 %}
+//CSPYCE_DEFAULT:result:2000
 
 /***********************************************************************
 * -Procedure gffove_c ( GF, is target in FOV? )
@@ -6230,7 +6233,7 @@ extern void gfdist_c(
 * udrepf     I   Function that finalizes progress reporting.
 * bail       I   Logical indicating program interrupt monitoring.
 * udbail     I   Name of a routine that signals a program interrupt.
-* cnfine     I  SPICE window to which the search is restricted.
+* cnfine     I   SPICE window to which the search is restricted.
 * result     O   SPICE window containing results.
 * windows    O   Array giving start/stop time pairs for the intervals found.
 * step       I   Time step for searching.
@@ -6241,11 +6244,10 @@ extern void gfdist_c(
 %rename (gffove) my_gffove_c;
 %apply (void RETURN_VOID) {void my_gffove_c};
 %apply (ConstSpiceDouble IN_ARRAY1[ANY]) {ConstSpiceDouble raydir[3]};
-
 %apply (SpiceDouble OUT_ARRAY2[ANY][ANY], SpiceInt *SIZE1)
                 {(SpiceDouble windows[WINDOWS][2], SpiceInt *intervals)};
 %apply (SpiceCellDouble* INPUT)  {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT) {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)  {SpiceCell *result};
 
 %inline %{
     void my_gffove_c(
@@ -6268,6 +6270,8 @@ extern void gfdist_c(
                  SPICEFALSE, NULL, cnfine, result);
     }
 %}
+//CSPYCE_DEFAULT:result:2000
+
 
 /***********************************************************************
 * -Procedure gfilum_c ( GF, illumination angle search )
@@ -6428,7 +6432,7 @@ extern void gfilum_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *abcorr};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 %inline %{
     void my_gfocce_c(
@@ -6453,6 +6457,8 @@ extern void gfilum_c(
                  SPICEFALSE, NULL, cnfine, result);
     }
 %}
+//CSPYCE_DEFAULT:result:2000
+
 
 /***********************************************************************
 * -Procedure gfoclt_c ( GF, find occultation )
@@ -6513,7 +6519,7 @@ extern void gfilum_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *abcorr};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 
 extern void gfoclt_c(
@@ -6530,6 +6536,8 @@ extern void gfoclt_c(
         SpiceCell      *cnfine,
         SpiceCell      *result
 );
+//CSPYCE_DEFAULT:result:2000
+
 
 /***********************************************************************
 * -Procedure gfpa_c ( GF, phase angle search )
@@ -6582,7 +6590,7 @@ extern void gfoclt_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *relate};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 
 extern void gfpa_c(
@@ -6598,6 +6606,7 @@ extern void gfpa_c(
         SpiceCell      *cnfine,
         SpiceCell      *result
 );
+//CSPYCE_DEFAULT:result:2000
 
 /***********************************************************************
 * -Procedure gfposc_c (GF, observer-target vector coordinate search)
@@ -6657,7 +6666,7 @@ extern void gfpa_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *coord};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *relate};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 extern void gfposc_c(
         ConstSpiceChar *target,
@@ -6674,6 +6683,8 @@ extern void gfposc_c(
         SpiceCell      *cnfine,
         SpiceCell      *result
 );
+//CSPYCE_DEFAULT:result:2000
+
 
 /***********************************************************************
 * -Procedure gfrfov_c ( GF, is ray in FOV? )
@@ -6724,7 +6735,7 @@ extern void gfposc_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *abcorr};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 extern void gfrfov_c(
         ConstSpiceChar   *inst,
@@ -6736,6 +6747,7 @@ extern void gfrfov_c(
         SpiceCell        *cnfine,
         SpiceCell        *result
 );
+//CSPYCE_DEFAULT:result:2000
 
 /***********************************************************************
 * -Procedure gfrr_c (GF, range rate search )
@@ -6784,7 +6796,7 @@ extern void gfrfov_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *relate};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 extern void gfrr_c(
         ConstSpiceChar *target,
@@ -6798,6 +6810,8 @@ extern void gfrr_c(
         SpiceCell      *cnfine,
         SpiceCell      *result
 );
+//CSPYCE_DEFAULT:result:2000
+
 
 /***********************************************************************
 * -Procedure gfsep_c (GF, angular separation search)
@@ -6865,7 +6879,7 @@ extern void gfrr_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *relate};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 extern void gfsep_c(
         ConstSpiceChar *targ1,
@@ -6884,6 +6898,7 @@ extern void gfsep_c(
         SpiceCell      *cnfine,
         SpiceCell      *result
 );
+//CSPYCE_DEFAULT:result:2000
 
 /***********************************************************************
 * -Procedure gfsntc_c (GF, surface intercept vector coordinate search)
@@ -6951,7 +6966,7 @@ extern void gfsep_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *coord};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *relate};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 extern void gfsntc_c(
         ConstSpiceChar   *target,
@@ -6971,6 +6986,7 @@ extern void gfsntc_c(
         SpiceCell        *cnfine,
         SpiceCell        *result
 );
+//CSPYCE_DEFAULT:result:2000
 
 /***********************************************************************
 * -Procedure gfstol_c ( GF, set a tolerance value for GF )
@@ -7056,7 +7072,7 @@ extern void gfstol_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *coord};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *relate};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 extern void gfsubc_c(
         ConstSpiceChar *target,
@@ -7074,6 +7090,7 @@ extern void gfsubc_c(
         SpiceCell      *cnfine,
         SpiceCell      *result
 );
+//CSPYCE_DEFAULT:result:2000
 
 /***********************************************************************
 * -Procedure gftfov_c ( GF, is target in FOV? )
@@ -7127,7 +7144,7 @@ extern void gfsubc_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *abcorr};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (SpiceCellDouble* INPUT)       {SpiceCell *cnfine};
-%apply (SpiceCellDouble* OUTPUT)      {SpiceCell *result};
+%apply (SpiceCellDouble* INOUT)       {SpiceCell *result};
 
 extern void gftfov_c(
         ConstSpiceChar *inst,
@@ -7140,6 +7157,7 @@ extern void gftfov_c(
         SpiceCell      *cnfine,
         SpiceCell      *result
 );
+//CSPYCE_DEFAULT:result:20000
 
 /***********************************************************************
 * -Procedure hrmesp_c ( Hermite polynomial interpolation, equal spacing )

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -3154,12 +3154,16 @@ typedef SpiceCell SpiceCellDouble;
 {
 //      $1_type $1_name
 //      Type *OUTPUT
+    ERROR A SpiceCell should never be an output-only argument. "$1_type $1_name" in "$symname".
+#if 0
+    foobar baz bym
     record = PyObject_CallMethod(SWIG_CALLBACK_CLASS , "create_spice_cell", "i", TypeCode);
     TEST_MALLOC_FAILURE(record);
 
     PyObject *header_address = PyObject_GetAttrString(record, "_header_address");
     $1 = PyLong_AsVoidPtr(header_address);
     Py_XDECREF(header_address);
+#endif
 }
 
 %typemap(argout)

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -452,10 +452,6 @@ void ellipse_out(SpiceEllipse *arg);
     void SpiceCell_append(SpiceCell *arg, SpiceInt value) {
         appndi_c(value, arg);
     }
-
-    void SpiceCell_out(SpiceCell *arg, SpiceDouble value) {
-        appndd_c(value, arg);
-    }
 %}
 
 %apply (SpiceCellInt* INPUT) {SpiceCell *arg};
@@ -463,9 +459,6 @@ int SpiceCell_in(SpiceCell *arg);
 
 %apply (SpiceCellInt* INOUT) {SpiceCell *arg};
 void SpiceCell_append(SpiceCell *arg, SpiceInt value);
-
-%apply (SpiceCellDouble* OUTPUT) {SpiceCell *arg};
-void SpiceCell_out(SpiceCell *arg, SpiceDouble value);
 
 %{
     const SpiceChar* decode_filename(const char* filename) {


### PR DESCRIPTION
FIx #154 
ckcov now gets a larger SpiceCell by default.
All functions that return a SpiceCell can now set the size of the return value.