### PR TITLE
Install swig on MacOs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Get swig on MacOs
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew update
+          brew install swig
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Swig was dropped when github runners were updated from MacOS-12 to MacOS-14-arm64

FIXES #163 