### PR TITLE
Updates for numpy 2.0.0

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
+          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.9'
           CIBW_BEFORE_BUILD: 'pip3 install numpy setuptools setuptools_scm && python3 setup.py generate && git status && git log --decorate -n 3'
           CIBW_SKIP: 'pp* *musllinux* *cp27mu*'
           CIBW_ARCHS: 'auto64'

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
+          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.9'
           CIBW_BEFORE_BUILD: 'pip3 install numpy setuptools setuptools_scm && python3 setup.py generate && git status && git log --decorate -n 3'
           CIBW_SKIP: 'pp* *musllinux* *cp27mu*'
           CIBW_ARCHS: 'auto64'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,12 +41,6 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
 
-      - name: Maybe revert to NumPy 1.26
-        if: matrix.numpy-version == 'np1'
-        run: |
-          python -m pip uninstall -y numpy
-          python -m pip install numpy==1.26.4
-
       - name: Cache CSPICE source code
         uses: actions/cache@v3
         env:
@@ -99,6 +93,12 @@ jobs:
       - name: Install cspyce
         run: |
           python -m pip install .
+
+      - name: Maybe revert to NumPy 1.26
+        if: matrix.numpy-version == 'np1'
+        run: |
+          python -m pip uninstall -y numpy
+          python -m pip install numpy==1.26.4
 
       - name: Test with coverage
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
-        numpy-version: [ np1, np2 ]
       fail-fast: false
     steps:
       - name: Checkout
@@ -94,8 +93,10 @@ jobs:
         run: |
           python -m pip install .
 
+      # We want to test operation with NumPy 1.x without needing a whole new matrix,
+      # so we arbitrarily choose that 3.10 should use 1.x instead of 2.x
       - name: Maybe revert to NumPy 1.26
-        if: matrix.numpy-version == 'np1'
+        if: matrix.python-version == '3.10'
         run: |
           python -m pip uninstall -y numpy
           python -m pip install numpy==1.26.4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
-        numpy1: [ yes, no ]
+        numpy-version: [ np1, np2 ]
       fail-fast: false
     steps:
       - name: Checkout
@@ -42,9 +42,9 @@ jobs:
           python -m pip install -r requirements.txt
 
       - name: Maybe revert to NumPy 1.26
-        if: matrix.numpy1 == 'yes'
+        if: matrix.numpy-version == 'np1'
         run: |
-          python -m pip uninstall numpy
+          python -m pip uninstall -y numpy
           python -m pip install numpy==1.26.4
 
       - name: Cache CSPICE source code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        numpy1: [ yes, no ]
       fail-fast: false
     steps:
       - name: Checkout
@@ -39,6 +40,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -r requirements.txt
+
+      - name: Maybe revert to NumPy 1.26
+        if: matrix.numpy1 == 'yes'
+        run: |
+          python -m pip uninstall numpy
+          python -m pip install numpy==1.26.4
 
       - name: Cache CSPICE source code
         uses: actions/cache@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to `cspyce` will be documented here
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project tries to adhere to [Semantic Versioning](http://semver.org/).
 
-## [2.2.6] - 2024-06-18
-Recompiled with NumPy 2.0.0, which supports both NumPy 1.x and 2.x.
+## [2.3.0] - 2024-06-18
+Recompiled with NumPy 2.0.0, which supports both NumPy 1.x and 2.x. 
+Python 3.8 no longer supported!
+
+## [2.2.6] - 2024-05-14
+Fixed problems with compiling on MacOS. Added contributing guide and code of 
+conduct. Other minor cosmetic changes.
 
 ## [2.2.5] - 2024-02-05
 Fix problem with too many boddefs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `cspyce` will be documented here
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## [2.2.6] - 2024-06-18
+Recompiled with NumPy 2.0.0, which supports both NumPy 1.x and 2.x.
+
 ## [2.2.5] - 2024-02-05
 Fix problem with too many boddefs.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ array inputs, and aliases.
 
 `cspyce` may be installed by running `pip install cspyce`.
 
-Python versions 3.8 thru 3.12 are currently supported, with pre-built wheels
+Python versions 3.9 thru 3.12 are currently supported, with pre-built wheels
 available for Linux, MacOS, and Windows.
 
 If you are looking for information on running or distributing this code from

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ array inputs, and aliases.
 `cspyce` may be installed by running `pip install cspyce`.
 
 Python versions 3.9 thru 3.12 are currently supported, with pre-built wheels
-available for Linux, MacOS, and Windows.
+available for Linux, MacOS, and Windows. NumPy 1.x and 2.x are supported.
 
 If you are looking for information on running or distributing this code from
 the GitHub sources, look at the file `README-developers.md` in this directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ name = "cspyce"
 dynamic = ["version"]
 description = "High-performance Python interface to the NAIF CSPICE library"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "numpy",
+    "numpy>=2",
 ]
 license = {text = "Apache-2.0"}
 maintainers = [
@@ -23,7 +23,6 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Astronomy",
   "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "High-performance Python interface to the NAIF CSPICE library"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "numpy>=2",
+    "numpy",
 ]
 license = {text = "Apache-2.0"}
 maintainers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ coverage
 pytest
 pytest-cov
 requests
-numpy
+numpy>=2.0.0
 setuptools


### PR DESCRIPTION
- Changed tests and builds to only use Python 3.9+
- Updated requirements.txt to require NumPy 2.0.0+
- Added matrix tests against both NumPy 1.26.4 and 2.0.0+
- Updated change log and readme accordingly
