### PR TITLE
Remove np.asfarray from array_support.py for Numpy 2.0 compatibility

### DIFF
--- a/cspyce/array_support.py
+++ b/cspyce/array_support.py
@@ -43,7 +43,7 @@ def array_version(func):
     exists, just return it. If there is no vector version, the array version is
     simply the scalar version.
     """
- f
+
     if hasattr(func, 'array'):
         return func.array
 

--- a/cspyce/array_support.py
+++ b/cspyce/array_support.py
@@ -43,7 +43,7 @@ def array_version(func):
     exists, just return it. If there is no vector version, the array version is
     simply the scalar version.
     """
-
+ f
     if hasattr(func, 'array'):
         return func.array
 
@@ -191,7 +191,7 @@ def _exec_with_broadcasting(func, *args, **keywords):
         # Convert to floating-point array
         error = False
         try:
-            arg = np.asfarray(arg)
+            arg = np.asarray(arg, dtype=np.float64)
         except ValueError:
             error = True
 


### PR DESCRIPTION
Title says it all. There was one occurrence of np.afarray.